### PR TITLE
Create `onion-i2p.pac` PAC file

### DIFF
--- a/onion-i2p.pac
+++ b/onion-i2p.pac
@@ -14,15 +14,8 @@ const I2P_Hosts = new Array("*.i2p");    // Array of shExp patterns; a hostname 
 
 function FindProxyForURL(url, host) { 
 	proto_spec = "DIRECT";
-  found_match = false;
- 	Tor_Hosts.forEach(function(pattern, index, array) {
-		if (found_match) { return; }
-		if (shExpMatch(host, pattern)) { proto_spec="SOCKS5 127.0.0.1:9050"; found_match=true; return; }  // set ToR as soon as a pattern matches
-	});
- 	I2P_Hosts.forEach(function(pattern, index, array) {
-	  if (found_match) { return; }
-		if (shExpMatch(host, pattern)) { proto_spec="SOCKS5 127.0.0.1:4447"; found_match=true; return; }  // set ToR as soon as a pattern matches
-	});
+	if (shExpMatch(host, "*.onion")) { proto_spec="SOCKS5 127.0.0.1:9050"; found_match=true; }  // set ToR as soon as a pattern matches
+	if (shExpMatch(host, "*.i2p")) { proto_spec="SOCKS5 127.0.0.1:4447"; found_match=true; }  // set I2P as soon as a pattern matches
 
 	return proto_spec;
 }

--- a/onion-i2p.pac
+++ b/onion-i2p.pac
@@ -7,11 +7,6 @@
 //   then those are loaded without a proxy, which can leak your location
 //   and/or identity. This is NOT A REPLACEMENT FOR A FULL TOR BROWSER CONFIG
 
-// Edit these arrays to add other hosts matching patterns you want to route
-//   using a privacy network
-const ToR_Hosts = new Array("*.onion");  // Array of shExp patterns; a hostname that matches will route over ToR
-const I2P_Hosts = new Array("*.i2p");    // Array of shExp patterns; a hostname that matches will route over I2P
-
 function FindProxyForURL(url, host) { 
 	proto_spec = "DIRECT";
 	if (shExpMatch(host, "*.onion")) { proto_spec="SOCKS5 127.0.0.1:9050"; found_match=true; }  // set ToR as soon as a pattern matches

--- a/onion-i2p.pac
+++ b/onion-i2p.pac
@@ -1,0 +1,28 @@
+// (c) 2025 Highly Capable, release under MIT License; see end of file
+// Proxy AutoConfig file to route .onion and .i2p requests to localhost
+//   SOCKS proxies.
+//
+// PRIVACY ALERT -- using this PAC file lets you surf onion and i2p sites
+//   but is "leaky"; if an onion site references clearweb content/assets,
+//   then those are loaded without a proxy, which can leak your location
+//   and/or identity. This is NOT A REPLACEMENT FOR A FULL TOR BROWSER CONFIG
+
+// Edit these arrays to add other hosts matching patterns you want to route
+//   using a privacy network
+const ToR_Hosts = new Array("*.onion");  // Array of shExp patterns; a hostname that matches will route over ToR
+const I2P_Hosts = new Array("*.i2p");    // Array of shExp patterns; a hostname that matches will route over I2P
+
+function FindProxyForURL(url, host) { 
+	proto_spec = "DIRECT";
+  found_match = false;
+ 	Tor_Hosts.forEach(function(pattern, index, array) {
+		if (found_match) { return; }
+		if (shExpMatch(host, pattern)) { proto_spec="SOCKS5 127.0.0.1:9050"; found_match=true; return; }  // set ToR as soon as a pattern matches
+	});
+ 	I2P_Hosts.forEach(function(pattern, index, array) {
+	  if (found_match) { return; }
+		if (shExpMatch(host, pattern)) { proto_spec="SOCKS5 127.0.0.1:4447"; found_match=true; return; }  // set ToR as soon as a pattern matches
+	});
+
+	return proto_spec;
+}

--- a/onion-i2p.pac
+++ b/onion-i2p.pac
@@ -8,9 +8,8 @@
 //   and/or identity. This is NOT A REPLACEMENT FOR A FULL TOR BROWSER CONFIG
 
 function FindProxyForURL(url, host) { 
-	proto_spec = "DIRECT";
-	if (shExpMatch(host, "*.onion")) { proto_spec="SOCKS5 127.0.0.1:9050"; found_match=true; }  // set ToR as soon as a pattern matches
-	if (shExpMatch(host, "*.i2p")) { proto_spec="SOCKS5 127.0.0.1:4447"; found_match=true; }  // set I2P as soon as a pattern matches
+	if (shExpMatch(host, "*.onion")) { return "SOCKS5 127.0.0.1:9050"; }  // set ToR as soon as a pattern matches
+	if (shExpMatch(host, "*.i2p")) { return "SOCKS5 127.0.0.1:4447"; }    // set I2P as soon as a pattern matches
 
-	return proto_spec;
+	return "DIRECT";
 }


### PR DESCRIPTION
Simple PAC file to connect `.onion` and `.i2p` domains to local SOCKS proxies for the relevant privacy networks. Users must read privacy alert in PAC file before using.